### PR TITLE
correct usage of group_map

### DIFF
--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -58,7 +58,7 @@ test_that('group_map method preserves metadata', {
   purrr::walk(
     c(attr_preserved, class_preserved),
     exec,
-    !!!list(es, group_map, .f = as.data.frame)
+    !!!list(es, group_map, .f = function(dt,grp)as.data.frame(dt))
   )
 })
 


### PR DESCRIPTION
When data.table from github master is installed, `data.table::update_dev_pkg()` and then I run R CMD check expstudy, I get a new error, https://github.com/Rdatatable/data.table/issues/5533

As I understand, the error comes from an incorrect usage of `group_map` in your tests, which this PR corrects.

In detail 
`help("group_modify.dtplyr_step",package="dtplyr")` explains that `.f` is supposed to be a function of two arguments, where the second is a list of current values of the grouping variables
```
      .f: The name of a two argument function. The first argument is
          passed '.SD',the data.table representing the current group;
          the second argument is passed '.BY', a list giving the
          current values of the grouping variables. The function should
          return a list or data.table.
```
However your test code specifies `.f = as.data.frame` which is problematic since it has signature `as.data.frame(x, row.names = NULL, optional = FALSE, ...)` --- the second argument is used as row names (not grouping variables).

This is not an issue (your tests pass) when data.table release version from CRAN is installed, because that version of `as.data.frame.data.table` ignores arguments other than the first. The new version of data.table from github master no longer ignores the second argument, which is why there is a new test failure.
My proposed fix is to create an anonymous function to use as `.f`, which ignores the second argument (grouping variables).

Can you please merge this PR and then submit a new version to CRAN?
This will help facilitate releasing a new version of data.table to CRAN. (data.table devs must make sure all reverse dependencies do not break, before submitting a new version to CRAN)